### PR TITLE
Add log entry for "claimDeveloperRewards"

### DIFF
--- a/builtInFunctions/claimDeveloperRewards.go
+++ b/builtInFunctions/claimDeveloperRewards.go
@@ -96,7 +96,6 @@ func (c *claimDeveloperRewards) ProcessBuiltinFunction(
 		return vmOutput, nil
 	}
 
-	// The call is intra-shard.
 	err = acntSnd.AddToBalance(value)
 	if err != nil {
 		return nil, err

--- a/builtInFunctions/claimDeveloperRewards.go
+++ b/builtInFunctions/claimDeveloperRewards.go
@@ -102,7 +102,6 @@ func (c *claimDeveloperRewards) ProcessBuiltinFunction(
 	}
 
 	if vmcommon.IsSmartContractAddress(vmInput.CallerAddr) {
-		// Question for review: the output accounts map is cleared, since this is a contract-to-contract call?
 		vmOutput.OutputAccounts = make(map[string]*vmcommon.OutputAccount)
 	}
 

--- a/builtInFunctions/claimDeveloperRewards.go
+++ b/builtInFunctions/claimDeveloperRewards.go
@@ -48,7 +48,9 @@ func (c *claimDeveloperRewards) ProcessBuiltinFunction(
 	}
 	gasRemaining := computeGasRemaining(acntSnd, vmInput.GasProvided, c.gasCost)
 	if check.IfNil(acntDst) {
-		// cross-shard call, in sender shard only the gas is taken out
+		// The call is cross-shard, and we are at the sender shard.
+		// Here, in the sender shard, only the gas is taken out.
+		// Log entry does not need to be added.
 		return &vmcommon.VMOutput{ReturnCode: vmcommon.Ok, GasRemaining: gasRemaining}, nil
 	}
 
@@ -89,19 +91,42 @@ func (c *claimDeveloperRewards) ProcessBuiltinFunction(
 	vmOutput.OutputAccounts[string(outputAcc.Address)] = outputAcc
 
 	if check.IfNil(acntSnd) {
+		// The call is cross-shard, and we are at the destination shard.
+		addLogEntryForClaimDeveloperRewards(vmInput, vmOutput, value, vmInput.CallerAddr)
 		return vmOutput, nil
 	}
 
+	// The call is intra-shard.
 	err = acntSnd.AddToBalance(value)
 	if err != nil {
 		return nil, err
 	}
 
 	if vmcommon.IsSmartContractAddress(vmInput.CallerAddr) {
+		// Question for review: the output accounts map is cleared, since this is a contract-to-contract call?
 		vmOutput.OutputAccounts = make(map[string]*vmcommon.OutputAccount)
 	}
 
+	addLogEntryForClaimDeveloperRewards(vmInput, vmOutput, value, vmInput.CallerAddr)
 	return vmOutput, nil
+}
+
+func addLogEntryForClaimDeveloperRewards(
+	vmInput *vmcommon.ContractCallInput,
+	vmOutput *vmcommon.VMOutput,
+	value *big.Int,
+	developerAddress []byte,
+) {
+	valueAsBytes := value.Bytes()
+
+	logEntry := &vmcommon.LogEntry{
+		Identifier: []byte(vmInput.Function),
+		Address:    vmInput.RecipientAddr,
+		Topics:     [][]byte{valueAsBytes, developerAddress},
+		Data:       nil,
+	}
+	vmOutput.Logs = make([]*vmcommon.LogEntry, 1)
+	vmOutput.Logs[0] = logEntry
 }
 
 // IsInterfaceNil returns true if underlying object is nil

--- a/builtInFunctions/claimDeveloperRewards_test.go
+++ b/builtInFunctions/claimDeveloperRewards_test.go
@@ -31,6 +31,7 @@ func TestClaimDeveloperRewards_ProcessBuiltinFunction(t *testing.T) {
 	vmOutput, err = cdr.ProcessBuiltinFunction(nil, nil, vmInput)
 	require.Nil(t, err)
 	require.NotNil(t, vmOutput)
+	require.Equal(t, 0, len(vmOutput.Logs))
 
 	vmOutput, err = cdr.ProcessBuiltinFunction(nil, acc, vmInput)
 	require.Nil(t, vmOutput)
@@ -44,6 +45,8 @@ func TestClaimDeveloperRewards_ProcessBuiltinFunction(t *testing.T) {
 	require.Equal(t, 1, len(vmOutput.OutputAccounts[string(vmInput.CallerAddr)].OutputTransfers))
 	require.Equal(t, value, vmOutput.OutputAccounts[string(vmInput.CallerAddr)].OutputTransfers[0].Value)
 	require.Equal(t, uint64(0), vmOutput.GasRemaining)
+	require.Equal(t, 1, len(vmOutput.Logs))
+	require.Equal(t, [][]byte{value.Bytes(), acc.OwnerAddress}, vmOutput.Logs[0].Topics)
 
 	acc.OwnerAddress = sender
 	acc.AddToDeveloperReward(value)
@@ -51,4 +54,6 @@ func TestClaimDeveloperRewards_ProcessBuiltinFunction(t *testing.T) {
 	vmOutput, err = cdr.ProcessBuiltinFunction(acc, acc, vmInput)
 	require.Nil(t, err)
 	require.Equal(t, vmOutput.GasRemaining, vmInput.GasProvided-cdr.gasCost)
+	require.Equal(t, 1, len(vmOutput.Logs))
+	require.Equal(t, [][]byte{value.Bytes(), acc.OwnerAddress}, vmOutput.Logs[0].Topics)
 }

--- a/builtInFunctions/claimDeveloperRewards_test.go
+++ b/builtInFunctions/claimDeveloperRewards_test.go
@@ -57,3 +57,23 @@ func TestClaimDeveloperRewards_ProcessBuiltinFunction(t *testing.T) {
 	require.Equal(t, 1, len(vmOutput.Logs))
 	require.Equal(t, [][]byte{value.Bytes(), acc.OwnerAddress}, vmOutput.Logs[0].Topics)
 }
+
+func TestAddLogEntryForClaimDeveloperRewards(t *testing.T) {
+	t.Parallel()
+
+	vmInput := &vmcommon.ContractCallInput{
+		Function:      "ClaimDeveloperRewards",
+		RecipientAddr: []byte("contract"),
+	}
+
+	vmOutput := &vmcommon.VMOutput{}
+	value := big.NewInt(42)
+	developerAddress := []byte("developer")
+
+	addLogEntryForClaimDeveloperRewards(vmInput, vmOutput, value, developerAddress)
+
+	require.Equal(t, 1, len(vmOutput.Logs))
+	require.Equal(t, []byte(vmInput.Function), vmOutput.Logs[0].Identifier)
+	require.Equal(t, vmInput.RecipientAddr, vmOutput.Logs[0].Address)
+	require.Equal(t, [][]byte{value.Bytes(), developerAddress}, vmOutput.Logs[0].Topics)
+}

--- a/builtInFunctions/deleteUserName.go
+++ b/builtInFunctions/deleteUserName.go
@@ -87,7 +87,7 @@ func addLogEntryForUserNameChange(
 	vmInput *vmcommon.ContractCallInput,
 	vmOutput *vmcommon.VMOutput,
 	oldUserName []byte,
-) *vmcommon.LogEntry {
+) {
 	logEntry := &vmcommon.LogEntry{
 		Identifier: []byte(vmInput.Function),
 		Address:    vmInput.RecipientAddr,
@@ -96,7 +96,6 @@ func addLogEntryForUserNameChange(
 	}
 	vmOutput.Logs = make([]*vmcommon.LogEntry, 1)
 	vmOutput.Logs[0] = logEntry
-	return logEntry
 }
 
 // IsInterfaceNil returns true if underlying object in nil


### PR DESCRIPTION
When processing a `ClaimDeveloperRewards`  built-in function, add an event log:

```
identifier = "ClaimDeveloperRewards"
address = vmInput.RecipientAddr
topics = {  value, developerAddress }
data = nil
```

Tested on Testnet (with direct `ClaimDeveloperRewards`, with indirect ones - via parent contracts):
 - Account: https://testnet-explorer.multiversx.com/accounts/erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7
 - Epochs: 154 - 155

Tested using Rosetta checker (on Testnet).