### PR TITLE
ESDT local burn enabled for cross chain operations

### DIFF
--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -253,14 +253,19 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
+	crossChainTokenCheckerHandler, err := NewCrossChainTokenChecker(b.selfESDTPrefix)
+	if err != nil {
+		return err
+	}
+
 	newFunc, err = NewESDTLocalBurnFunc(
 		ESDTLocalBurnFuncArgs{
-			FuncGasCost:           b.gasConfig.BuiltInCost.ESDTLocalBurn,
-			Marshaller:            b.marshaller,
-			GlobalSettingsHandler: globalSettingsFunc,
-			RolesHandler:          setRoleFunc,
-			EnableEpochsHandler:   b.enableEpochsHandler,
-			SelfESDTPrefix:        b.selfESDTPrefix,
+			FuncGasCost:            b.gasConfig.BuiltInCost.ESDTLocalBurn,
+			Marshaller:             b.marshaller,
+			GlobalSettingsHandler:  globalSettingsFunc,
+			RolesHandler:           setRoleFunc,
+			EnableEpochsHandler:    b.enableEpochsHandler,
+			CrossChainTokenChecker: crossChainTokenCheckerHandler,
 		},
 	)
 	if err != nil {

--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -27,6 +27,7 @@ type ArgsCreateBuiltInFunctionContainer struct {
 	GuardedAccountHandler            vmcommon.GuardedAccountHandler
 	MaxNumOfAddressesForTransferRole uint32
 	ConfigAddress                    []byte
+	SelfESDTPrefix                   []byte
 }
 
 type builtInFuncCreator struct {
@@ -44,6 +45,7 @@ type builtInFuncCreator struct {
 	guardedAccountHandler            vmcommon.GuardedAccountHandler
 	maxNumOfAddressesForTransferRole uint32
 	configAddress                    []byte
+	selfESDTPrefix                   []byte
 }
 
 // NewBuiltInFunctionsCreator creates a component which will instantiate the built in functions contracts
@@ -85,6 +87,7 @@ func NewBuiltInFunctionsCreator(args ArgsCreateBuiltInFunctionContainer) (*built
 		guardedAccountHandler:            args.GuardedAccountHandler,
 		maxNumOfAddressesForTransferRole: args.MaxNumOfAddressesForTransferRole,
 		configAddress:                    args.ConfigAddress,
+		selfESDTPrefix:                   args.SelfESDTPrefix,
 	}
 
 	b.gasConfig, err = createGasConfig(args.GasMap)
@@ -250,7 +253,16 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTLocalBurnFunc(b.gasConfig.BuiltInCost.ESDTLocalBurn, b.marshaller, globalSettingsFunc, setRoleFunc, b.enableEpochsHandler)
+	newFunc, err = NewESDTLocalBurnFunc(
+		ESDTLocalBurnFuncArgs{
+			FuncGasCost:           b.gasConfig.BuiltInCost.ESDTLocalBurn,
+			Marshaller:            b.marshaller,
+			GlobalSettingsHandler: globalSettingsFunc,
+			RolesHandler:          setRoleFunc,
+			EnableEpochsHandler:   b.enableEpochsHandler,
+			SelfESDTPrefix:        b.selfESDTPrefix,
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -258,16 +258,15 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTLocalBurnFunc(
-		ESDTLocalBurnFuncArgs{
-			FuncGasCost:            b.gasConfig.BuiltInCost.ESDTLocalBurn,
-			Marshaller:             b.marshaller,
-			GlobalSettingsHandler:  globalSettingsFunc,
-			RolesHandler:           setRoleFunc,
-			EnableEpochsHandler:    b.enableEpochsHandler,
-			CrossChainTokenChecker: crossChainTokenCheckerHandler,
-		},
-	)
+	argsEsdtLocalBurn := ESDTLocalBurnFuncArgs{
+		FuncGasCost:            b.gasConfig.BuiltInCost.ESDTLocalBurn,
+		Marshaller:             b.marshaller,
+		GlobalSettingsHandler:  globalSettingsFunc,
+		RolesHandler:           setRoleFunc,
+		EnableEpochsHandler:    b.enableEpochsHandler,
+		CrossChainTokenChecker: crossChainTokenCheckerHandler,
+	}
+	newFunc, err = NewESDTLocalBurnFunc(argsEsdtLocalBurn)
 	if err != nil {
 		return err
 	}

--- a/builtInFunctions/crossChainTokenChecker.go
+++ b/builtInFunctions/crossChainTokenChecker.go
@@ -1,0 +1,45 @@
+package builtInFunctions
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/multiversx/mx-chain-core-go/data/esdt"
+)
+
+type crossChainTokenChecker struct {
+	selfESDTPrefix []byte
+}
+
+// NewCrossChainTokenChecker creates a new cross chain token checker
+func NewCrossChainTokenChecker(selfESDTPrefix []byte) (*crossChainTokenChecker, error) {
+	ctc := &crossChainTokenChecker{
+		selfESDTPrefix: selfESDTPrefix,
+	}
+
+	if len(selfESDTPrefix) == 0 {
+		return ctc, nil
+	}
+
+	if !esdt.IsValidTokenPrefix(string(selfESDTPrefix)) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidTokenPrefix, selfESDTPrefix)
+	}
+
+	return ctc, nil
+}
+
+// IsCrossChainOperation checks if the provided token comes from another chain/sovereign shard
+func (ctc *crossChainTokenChecker) IsCrossChainOperation(tokenID []byte) bool {
+	tokenPrefix, hasPrefix := esdt.IsValidPrefixedToken(string(tokenID))
+	// no prefix or malformed token in main chain operation
+	if !hasPrefix && len(ctc.selfESDTPrefix) == 0 {
+		return false
+	}
+
+	return !bytes.Equal([]byte(tokenPrefix), ctc.selfESDTPrefix)
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (ctc *crossChainTokenChecker) IsInterfaceNil() bool {
+	return ctc == nil
+}

--- a/builtInFunctions/crossChainTokenChecker_test.go
+++ b/builtInFunctions/crossChainTokenChecker_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewCrossChainTokenChecker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("main chain, should work", func(t *testing.T) {
+		ctc, err := NewCrossChainTokenChecker([]byte{})
+		require.Nil(t, err)
+		require.False(t, ctc.IsInterfaceNil())
+	})
+
+	t.Run("sovereign chain with invalid prefix, should not work", func(t *testing.T) {
+		ctc, err := NewCrossChainTokenChecker([]byte("PREFIX"))
+		require.ErrorIs(t, err, ErrInvalidTokenPrefix)
+		require.Nil(t, ctc)
+	})
+
+	t.Run("sovereign chain valid prefix, should work", func(t *testing.T) {
+		ctc, err := NewCrossChainTokenChecker([]byte("pref"))
+		require.Nil(t, err)
+		require.False(t, ctc.IsInterfaceNil())
+	})
+}
+
 func TestCrossChainTokenChecker_IsCrossChainOperation(t *testing.T) {
 	t.Parallel()
 

--- a/builtInFunctions/crossChainTokenChecker_test.go
+++ b/builtInFunctions/crossChainTokenChecker_test.go
@@ -1,0 +1,27 @@
+package builtInFunctions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrossChainTokenChecker_IsCrossChainOperation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cross chain operations in a sovereign shard", func(t *testing.T) {
+		ctc, _ := NewCrossChainTokenChecker([]byte("sov1"))
+
+		require.True(t, ctc.IsCrossChainOperation([]byte("ALICE-abcdef")))
+		require.True(t, ctc.IsCrossChainOperation([]byte("sov2-ALICE-abcdef")))
+		require.False(t, ctc.IsCrossChainOperation([]byte("sov1-ALICE-abcdef")))
+	})
+
+	t.Run("cross chain operations in a main chain", func(t *testing.T) {
+		ctc, _ := NewCrossChainTokenChecker(nil)
+
+		require.True(t, ctc.IsCrossChainOperation([]byte("sov2-ALICE-abcdef")))
+		require.True(t, ctc.IsCrossChainOperation([]byte("sov1-ALICE-abcdef")))
+		require.False(t, ctc.IsCrossChainOperation([]byte("ALICE-abcdef")))
+	})
+}

--- a/builtInFunctions/errors.go
+++ b/builtInFunctions/errors.go
@@ -220,3 +220,9 @@ var ErrInvalidVersion = errors.New("invalid version")
 
 // ErrNilBlockchainHook signals that a nil blockchain hook has been provided
 var ErrNilBlockchainHook = errors.New("nil blockchain hook")
+
+// ErrInvalidTokenPrefix signals that an invalid token prefix has been provided
+var ErrInvalidTokenPrefix = errors.New("invalid token prefix, should have max 4 (lowercase/alphanumeric) characters")
+
+// ErrNilCrossChainTokenChecker signals that a nil cross chain token checker has been provided
+var ErrNilCrossChainTokenChecker = errors.New("nil cross chain token checker has been provided")

--- a/builtInFunctions/esdtLocalBurn.go
+++ b/builtInFunctions/esdtLocalBurn.go
@@ -2,14 +2,13 @@ package builtInFunctions
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 	"sync"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data/esdt"
 	"github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -129,31 +128,13 @@ func (e *esdtLocalBurn) isAllowedToBurn(acntSnd vmcommon.UserAccountHandler, tok
 }
 
 func (e *esdtLocalBurn) isCrossChainOperation(tokenID []byte) bool {
-	if !isTokenPrefixValid(tokenID) {
+	tokenPrefix, hasPrefix := esdt.IsValidPrefixedToken(string(tokenID))
+	// normal tokens main chain operation
+	if !hasPrefix && len(e.selfESDTPrefix) == 0 {
 		return false
 	}
 
-	tokenIDPrefix, err := extractTokenIDPrefix(tokenID)
-	if err != nil {
-		return false
-	}
-
-	return !bytes.Equal(tokenIDPrefix, e.selfESDTPrefix)
-}
-
-func isTokenPrefixValid(tokenID []byte) bool {
-	return false
-}
-
-func extractTokenIDPrefix(tokenID []byte) ([]byte, error) {
-	tokenStr := string(tokenID)
-	tokenSplits := strings.Split(tokenStr, "-")
-	if len(tokenSplits) < 1 {
-		log.Error("extractTokenIDPrefix: validated a token id with prefix which does not have enough info", "tokenID", tokenStr)
-		return nil, errors.New("dsa")
-	}
-
-	return []byte(tokenSplits[0]), nil
+	return !bytes.Equal([]byte(tokenPrefix), e.selfESDTPrefix)
 }
 
 // IsInterfaceNil returns true if underlying object in nil

--- a/builtInFunctions/esdtLocalBurn_test.go
+++ b/builtInFunctions/esdtLocalBurn_test.go
@@ -75,6 +75,16 @@ func TestNewESDTLocalBurnFunc(t *testing.T) {
 			exError: ErrNilEnableEpochsHandler,
 		},
 		{
+			name: "NilCrossChainTokenChecker",
+			argsFunc: func() ESDTLocalBurnFuncArgs {
+				args := createESDTLocalBurnArgs()
+				args.CrossChainTokenChecker = nil
+
+				return args
+			},
+			exError: ErrNilCrossChainTokenChecker,
+		},
+		{
 			name: "Ok",
 			argsFunc: func() ESDTLocalBurnFuncArgs {
 				return createESDTLocalBurnArgs()

--- a/builtInFunctions/esdtLocalBurn_test.go
+++ b/builtInFunctions/esdtLocalBurn_test.go
@@ -167,7 +167,6 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_CannotAddToEsdtBalanceShouldErr(t 
 func TestEsdtLocalBurn_ProcessBuiltinFunction_ValueTooLong(t *testing.T) {
 	t.Parallel()
 
-	marshaller := &mock.MarshalizerMock{}
 	args := createESDTLocalBurnArgs()
 	args.FuncGasCost = 50
 	args.RolesHandler = &mock.ESDTRoleHandlerStub{
@@ -183,7 +182,7 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_ValueTooLong(t *testing.T) {
 			return &mock.DataTrieTrackerStub{
 				RetrieveValueCalled: func(_ []byte) ([]byte, uint32, error) {
 					esdtData := &esdt.ESDigitalToken{Value: big.NewInt(100)}
-					serializedEsdtData, err := marshaller.Marshal(esdtData)
+					serializedEsdtData, err := args.Marshaller.Marshal(esdtData)
 					return serializedEsdtData, 0, err
 				},
 			}
@@ -222,7 +221,6 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_ValueTooLong(t *testing.T) {
 func TestEsdtLocalBurn_ProcessBuiltinFunction_ShouldWork(t *testing.T) {
 	t.Parallel()
 
-	marshaller := &mock.MarshalizerMock{}
 	args := createESDTLocalBurnArgs()
 	args.FuncGasCost = 50
 	args.RolesHandler = &mock.ESDTRoleHandlerStub{
@@ -238,12 +236,12 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_ShouldWork(t *testing.T) {
 			return &mock.DataTrieTrackerStub{
 				RetrieveValueCalled: func(_ []byte) ([]byte, uint32, error) {
 					esdtData := &esdt.ESDigitalToken{Value: big.NewInt(100)}
-					serializedEsdtData, err := marshaller.Marshal(esdtData)
+					serializedEsdtData, err := args.Marshaller.Marshal(esdtData)
 					return serializedEsdtData, 0, err
 				},
 				SaveKeyValueCalled: func(key []byte, value []byte) error {
 					esdtData := &esdt.ESDigitalToken{}
-					_ = marshaller.Unmarshal(esdtData, value)
+					_ = args.Marshaller.Unmarshal(esdtData, value)
 					require.Equal(t, big.NewInt(99), esdtData.Value)
 					return nil
 				},
@@ -277,7 +275,6 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_ShouldWork(t *testing.T) {
 func TestEsdtLocalBurn_ProcessBuiltinFunction_WithGlobalBurn(t *testing.T) {
 	t.Parallel()
 
-	marshaller := &mock.MarshalizerMock{}
 	args := createESDTLocalBurnArgs()
 	args.FuncGasCost = 50
 	args.GlobalSettingsHandler = &mock.GlobalSettingsHandlerStub{
@@ -297,12 +294,12 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_WithGlobalBurn(t *testing.T) {
 			return &mock.DataTrieTrackerStub{
 				RetrieveValueCalled: func(_ []byte) ([]byte, uint32, error) {
 					esdtData := &esdt.ESDigitalToken{Value: big.NewInt(100)}
-					serializedEsdtData, err := marshaller.Marshal(esdtData)
+					serializedEsdtData, err := args.Marshaller.Marshal(esdtData)
 					return serializedEsdtData, 0, err
 				},
 				SaveKeyValueCalled: func(key []byte, value []byte) error {
 					esdtData := &esdt.ESDigitalToken{}
-					_ = marshaller.Unmarshal(esdtData, value)
+					_ = args.Marshaller.Unmarshal(esdtData, value)
 					require.Equal(t, big.NewInt(99), esdtData.Value)
 					return nil
 				},

--- a/builtInFunctions/esdtLocalBurn_test.go
+++ b/builtInFunctions/esdtLocalBurn_test.go
@@ -387,9 +387,15 @@ func TestCheckInputArgumentsForLocalAction_NotEnoughGas(t *testing.T) {
 func TestEsdtLocalBurn_ProcessBuiltinFunction_CrossChainOperations(t *testing.T) {
 	t.Parallel()
 
-	marshaller := &mock.MarshalizerMock{}
+	testEsdtLocalBurnCrossChainOperations(t, nil, []byte("sov1-TKN-abcdef"))
+	testEsdtLocalBurnCrossChainOperations(t, []byte("sov2"), []byte("sov1-TKN-abcdef"))
+	testEsdtLocalBurnCrossChainOperations(t, []byte("sov1"), []byte("TKN-abcdef"))
+}
+
+func testEsdtLocalBurnCrossChainOperations(t *testing.T, selfPrefix, crossChainToken []byte) {
 	args := createESDTLocalBurnArgs()
 	args.FuncGasCost = 50
+	args.CrossChainTokenChecker, _ = NewCrossChainTokenChecker(selfPrefix)
 
 	wasAllowedToExecuteCalled := false
 	args.RolesHandler = &mock.ESDTRoleHandlerStub{
@@ -411,6 +417,7 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_CrossChainOperations(t *testing.T)
 	initialBalance := big.NewInt(100)
 	burnValue := big.NewInt(44)
 	wasNewBalanceUpdated := false
+	marshaller := args.Marshaller
 	senderAcc := &mock.UserAccountStub{
 		AccountDataHandlerCalled: func() vmcommon.AccountDataHandler {
 			return &mock.DataTrieTrackerStub{
@@ -431,7 +438,6 @@ func TestEsdtLocalBurn_ProcessBuiltinFunction_CrossChainOperations(t *testing.T)
 		},
 	}
 
-	crossChainToken := []byte("sov1-TKN-abcdef")
 	vmOutput, err := esdtLocalBurnF.ProcessBuiltinFunction(senderAcc, &mock.AccountWrapMock{}, &vmcommon.ContractCallInput{
 		VMInput: vmcommon.VMInput{
 			CallValue:   big.NewInt(0),

--- a/builtInFunctions/interface.go
+++ b/builtInFunctions/interface.go
@@ -1,1 +1,7 @@
 package builtInFunctions
+
+// CrossChainTokenCheckerHandler should check if token is from another chain/sovereign shard
+type CrossChainTokenCheckerHandler interface {
+	IsCrossChainOperation(tokenID []byte) bool
+	IsInterfaceNil() bool
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/multiversx/mx-chain-core-go v1.2.21-0.20240508071047-fefea5737840
+	github.com/multiversx/mx-chain-core-go v1.2.21-0.20240517102534-7befa5957b5d
 	github.com/multiversx/mx-chain-logger-go v1.0.15-0.20240508072523-3f00a726af57
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/multiversx/mx-chain-core-go v1.2.20-0.20240328090024-e88291d59ace
+	github.com/multiversx/mx-chain-core-go v1.2.20-0.20240423091937-9ba698bcdbd2
 	github.com/multiversx/mx-chain-logger-go v1.0.14-0.20240129144507-d00e967c890c
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxd
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/multiversx/mx-chain-core-go v1.2.21-0.20240508071047-fefea5737840 h1:2mCrTUmbbA+Xv4UifZY9xptrGjcJBcJ2wavSb4FwejU=
-github.com/multiversx/mx-chain-core-go v1.2.21-0.20240508071047-fefea5737840/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.2.21-0.20240517102534-7befa5957b5d h1:Eu4VgqwCyqttR1L8u1SrqWdjec9FRwQ1ZDKC7br9a44=
+github.com/multiversx/mx-chain-core-go v1.2.21-0.20240517102534-7befa5957b5d/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-logger-go v1.0.15-0.20240508072523-3f00a726af57 h1:g9t410dqjcb7UUptbVd/H6Ua12sEzWU4v7VplyNvRZ0=
 github.com/multiversx/mx-chain-logger-go v1.0.15-0.20240508072523-3f00a726af57/go.mod h1:cY6CIXpndW5g5PTPn4WzPwka/UBEf+mgw+PSY5pHGAU=
 github.com/multiversx/protobuf v1.3.2 h1:RaNkxvGTGbA0lMcnHAN24qE1G1i+Xs5yHA6MDvQ4mSM=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxd
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/multiversx/mx-chain-core-go v1.2.20-0.20240328090024-e88291d59ace h1:sCXg0IlWmi0k5mC3BmUVCKVrxatGRQKGmqVS/froLDw=
-github.com/multiversx/mx-chain-core-go v1.2.20-0.20240328090024-e88291d59ace/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.2.20-0.20240423091937-9ba698bcdbd2 h1:Xr2p0Hw3SrmQz4eujbz5Nl+wVP3ijC/sYQ5HcTgxOqY=
+github.com/multiversx/mx-chain-core-go v1.2.20-0.20240423091937-9ba698bcdbd2/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-logger-go v1.0.14-0.20240129144507-d00e967c890c h1:QIUOn8FgNRa5cir4BCWHZi/Qcr6Gg0eGNhns4+jy6+k=
 github.com/multiversx/mx-chain-logger-go v1.0.14-0.20240129144507-d00e967c890c/go.mod h1:fH/fR/GEBsDjPkBoZDVJMoYo2HhlA7++DP6QfITJ1N8=
 github.com/multiversx/protobuf v1.3.2 h1:RaNkxvGTGbA0lMcnHAN24qE1G1i+Xs5yHA6MDvQ4mSM=


### PR DESCRIPTION
Enabled ESDT local burn enabled for cross chain operations.
Added `CrossChainTokenChecker` interface to be used for local mint as well.