### PR TITLE
Cross chain tokens esdt nft mint with same nonce

### DIFF
--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -329,16 +330,18 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTNFTCreateFunc(
-		b.gasConfig.BuiltInCost.ESDTNFTCreate,
-		b.gasConfig.BaseOperationCost,
-		b.marshaller,
-		globalSettingsFunc,
-		setRoleFunc,
-		b.esdtStorageHandler,
-		b.accounts,
-		b.enableEpochsHandler,
-	)
+	argsESDTNFTCreate := ESDTNFTCreateFuncArgs{
+		FuncGasCost:                   b.gasConfig.BuiltInCost.ESDTNFTCreate,
+		Marshaller:                    b.marshaller,
+		RolesHandler:                  setRoleFunc,
+		EnableEpochsHandler:           b.enableEpochsHandler,
+		EsdtStorageHandler:            b.esdtStorageHandler,
+		Accounts:                      b.accounts,
+		GasConfig:                     b.gasConfig.BaseOperationCost,
+		GlobalSettingsHandler:         globalSettingsFunc,
+		CrossChainTokenCheckerHandler: crossChainTokenCheckerHandler,
+	}
+	newFunc, err = NewESDTNFTCreateFunc(argsESDTNFTCreate)
 	if err != nil {
 		return err
 	}

--- a/builtInFunctions/crossChainTokenChecker.go
+++ b/builtInFunctions/crossChainTokenChecker.go
@@ -3,13 +3,15 @@ package builtInFunctions
 import (
 	"bytes"
 	"fmt"
+	"sync"
 
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
 )
 
 type crossChainTokenChecker struct {
-	selfESDTPrefix       []byte
-	whiteListedAddresses map[string]struct{}
+	selfESDTPrefix        []byte
+	whiteListedAddresses  map[string]struct{}
+	mutWhiteListedAddress sync.RWMutex
 }
 
 // NewCrossChainTokenChecker creates a new cross chain token checker
@@ -51,6 +53,9 @@ func (ctc *crossChainTokenChecker) IsCrossChainOperationAllowed(address []byte, 
 }
 
 func (ctc *crossChainTokenChecker) isWhiteListed(address []byte) bool {
+	ctc.mutWhiteListedAddress.RLock()
+	defer ctc.mutWhiteListedAddress.RUnlock()
+
 	_, found := ctc.whiteListedAddresses[string(address)]
 	return found
 }

--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -44,6 +44,7 @@ type esdtNFTCreate struct {
 	crossChainTokenCheckerHandler CrossChainTokenCheckerHandler
 }
 
+// ESDTNFTCreateFuncArgs is a struct placeholder for args needed to create the esdt nft create func
 type ESDTNFTCreateFuncArgs struct {
 	FuncGasCost                   uint64
 	Marshaller                    vmcommon.Marshalizer
@@ -353,11 +354,12 @@ func getCrossChainTokenNonceAndCreator(args [][]byte, callType vm.CallType) (uin
 		minRequiredArgs++
 	}
 
-	if len(args) < minRequiredArgs {
-		return 0, nil, fmt.Errorf("%w for cross chain token mint, last 2 arguments should be the nonce and original creator", ErrInvalidNumberOfArguments)
+	argsLen := len(args)
+	if argsLen < minRequiredArgs {
+		return 0, nil, fmt.Errorf("%w for cross chain token mint, received: %d, expected: %d, 2 extra arguments should be the nonce and original creator",
+			ErrInvalidNumberOfArguments, argsLen, minRequiredArgs)
 	}
 
-	argsLen := len(args)
 	if !(callType == vm.ExecOnDestByCaller) {
 		nonceBytes := args[argsLen-2]
 		return big.NewInt(0).SetBytes(nonceBytes).Uint64(), args[argsLen-1], nil

--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -20,6 +20,8 @@ var (
 	noncePrefix = []byte(core.ProtectedKeyPrefix + core.ESDTNFTLatestNonceIdentifier)
 )
 
+const minNumOfArgsForCrossChainMint = 8
+
 type esdtNFTCreate struct {
 	baseAlwaysActiveHandler
 	keyPrefix                     []byte
@@ -300,8 +302,8 @@ func getLatestNonce(acnt vmcommon.UserAccountHandler, tokenID []byte) (uint64, e
 }
 
 func getCrossChainTokenNonce(args [][]byte) (uint64, error) {
-	if len(args) < 8 {
-		return 0, ErrInvalidNumberOfArguments
+	if len(args) < minNumOfArgsForCrossChainMint {
+		return 0, fmt.Errorf("%w for cross chain token mint, last argument should be the nonce", ErrInvalidNumberOfArguments)
 	}
 
 	nonceBytes := args[len(args)-1]

--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -126,16 +126,16 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 	if vmInput.CallType == vm.ExecOnDestByCaller {
 		minNumOfArgs = 8
 	}
-	lenArgs := len(vmInput.Arguments)
-	if lenArgs < minNumOfArgs {
+	argsLen := len(vmInput.Arguments)
+	if argsLen < minNumOfArgs {
 		return nil, fmt.Errorf("%w, wrong number of arguments", ErrInvalidArguments)
 	}
 
 	accountWithRoles := acntSnd
 	uris := vmInput.Arguments[6:]
 	if vmInput.CallType == vm.ExecOnDestByCaller {
-		scAddressWithRoles := vmInput.Arguments[lenArgs-1]
-		uris = vmInput.Arguments[6 : lenArgs-1]
+		scAddressWithRoles := vmInput.Arguments[argsLen-1]
+		uris = vmInput.Arguments[6 : argsLen-1]
 
 		if len(scAddressWithRoles) != len(vmInput.CallerAddr) {
 			return nil, ErrInvalidAddressLength

--- a/builtInFunctions/esdtNFTCreate_test.go
+++ b/builtInFunctions/esdtNFTCreate_test.go
@@ -10,28 +10,35 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
-	"github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-common-go/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/multiversx/mx-chain-vm-common-go/mock"
 )
 
-func createNftCreateWithStubArguments() *esdtNFTCreate {
-	nftCreate, _ := NewESDTNFTCreateFunc(
-		1,
-		vmcommon.BaseOperationCost{},
-		&mock.MarshalizerMock{},
-		&mock.GlobalSettingsHandlerStub{},
-		&mock.ESDTRoleHandlerStub{},
-		createNewESDTDataStorageHandler(),
-		&mock.AccountsStub{},
-		&mock.EnableEpochsHandlerStub{
+func createESDTNFTCreateArgs() ESDTNFTCreateFuncArgs {
+	return ESDTNFTCreateFuncArgs{
+		FuncGasCost:  0,
+		Marshaller:   &mock.MarshalizerMock{},
+		RolesHandler: &mock.ESDTRoleHandlerStub{},
+		EnableEpochsHandler: &mock.EnableEpochsHandlerStub{
 			IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
 				return flag == ValueLengthCheckFlag
 			},
 		},
-	)
+		EsdtStorageHandler:            createNewESDTDataStorageHandler(),
+		Accounts:                      &mock.AccountsStub{},
+		GasConfig:                     vmcommon.BaseOperationCost{},
+		GlobalSettingsHandler:         &mock.GlobalSettingsHandlerStub{},
+		CrossChainTokenCheckerHandler: &mock.CrossChainTokenCheckerMock{},
+	}
+}
 
+func createNftCreateWithStubArguments() *esdtNFTCreate {
+	args := createESDTNFTCreateArgs()
+	args.FuncGasCost = 1
+	nftCreate, _ := NewESDTNFTCreateFunc(args)
 	return nftCreate
 }
 
@@ -41,96 +48,62 @@ func TestNewESDTNFTCreateFunc_NilArgumentsShouldErr(t *testing.T) {
 	t.Run("nil marshaller should error", func(t *testing.T) {
 		t.Parallel()
 
-		nftCreate, err := NewESDTNFTCreateFunc(
-			0,
-			vmcommon.BaseOperationCost{},
-			nil,
-			&mock.GlobalSettingsHandlerStub{},
-			&mock.ESDTRoleHandlerStub{},
-			createNewESDTDataStorageHandler(),
-			&mock.AccountsStub{},
-			&mock.EnableEpochsHandlerStub{},
-		)
+		args := createESDTNFTCreateArgs()
+		args.Marshaller = nil
+		nftCreate, err := NewESDTNFTCreateFunc(args)
 		assert.True(t, check.IfNil(nftCreate))
 		assert.Equal(t, ErrNilMarshalizer, err)
 	})
 	t.Run("nil global settings handler should error", func(t *testing.T) {
 		t.Parallel()
 
-		nftCreate, err := NewESDTNFTCreateFunc(
-			0,
-			vmcommon.BaseOperationCost{},
-			&mock.MarshalizerMock{},
-			nil,
-			&mock.ESDTRoleHandlerStub{},
-			createNewESDTDataStorageHandler(),
-			&mock.AccountsStub{},
-			&mock.EnableEpochsHandlerStub{},
-		)
+		args := createESDTNFTCreateArgs()
+		args.GlobalSettingsHandler = nil
+		nftCreate, err := NewESDTNFTCreateFunc(args)
 		assert.True(t, check.IfNil(nftCreate))
 		assert.Equal(t, ErrNilGlobalSettingsHandler, err)
 	})
 	t.Run("nil roles handler should error", func(t *testing.T) {
 		t.Parallel()
 
-		nftCreate, err := NewESDTNFTCreateFunc(
-			0,
-			vmcommon.BaseOperationCost{},
-			&mock.MarshalizerMock{},
-			&mock.GlobalSettingsHandlerStub{},
-			nil,
-			createNewESDTDataStorageHandler(),
-			&mock.AccountsStub{},
-			&mock.EnableEpochsHandlerStub{},
-		)
+		args := createESDTNFTCreateArgs()
+		args.RolesHandler = nil
+		nftCreate, err := NewESDTNFTCreateFunc(args)
 		assert.True(t, check.IfNil(nftCreate))
 		assert.Equal(t, ErrNilRolesHandler, err)
 	})
 	t.Run("nil esdt storage handler should error", func(t *testing.T) {
 		t.Parallel()
 
-		nftCreate, err := NewESDTNFTCreateFunc(
-			0,
-			vmcommon.BaseOperationCost{},
-			&mock.MarshalizerMock{},
-			&mock.GlobalSettingsHandlerStub{},
-			&mock.ESDTRoleHandlerStub{},
-			nil,
-			&mock.AccountsStub{},
-			&mock.EnableEpochsHandlerStub{},
-		)
+		args := createESDTNFTCreateArgs()
+		args.EsdtStorageHandler = nil
+		nftCreate, err := NewESDTNFTCreateFunc(args)
 		assert.True(t, check.IfNil(nftCreate))
 		assert.Equal(t, ErrNilESDTNFTStorageHandler, err)
 	})
 	t.Run("nil enable epochs handler should error", func(t *testing.T) {
 		t.Parallel()
 
-		nftCreate, err := NewESDTNFTCreateFunc(
-			0,
-			vmcommon.BaseOperationCost{},
-			&mock.MarshalizerMock{},
-			&mock.GlobalSettingsHandlerStub{},
-			&mock.ESDTRoleHandlerStub{},
-			createNewESDTDataStorageHandler(),
-			&mock.AccountsStub{},
-			nil,
-		)
+		args := createESDTNFTCreateArgs()
+		args.EnableEpochsHandler = nil
+		nftCreate, err := NewESDTNFTCreateFunc(args)
 		assert.True(t, check.IfNil(nftCreate))
 		assert.Equal(t, ErrNilEnableEpochsHandler, err)
+	})
+	t.Run("nil cross chain token checker should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createESDTNFTCreateArgs()
+		args.CrossChainTokenCheckerHandler = nil
+		nftCreate, err := NewESDTNFTCreateFunc(args)
+		assert.True(t, check.IfNil(nftCreate))
+		assert.Equal(t, ErrNilCrossChainTokenChecker, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		nftCreate, err := NewESDTNFTCreateFunc(
-			0,
-			vmcommon.BaseOperationCost{},
-			&mock.MarshalizerMock{},
-			&mock.GlobalSettingsHandlerStub{},
-			&mock.ESDTRoleHandlerStub{},
-			createNewESDTDataStorageHandler(),
-			&mock.AccountsStub{},
-			&mock.EnableEpochsHandlerStub{},
-		)
+		args := createESDTNFTCreateArgs()
+		nftCreate, err := NewESDTNFTCreateFunc(args)
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(nftCreate))
 	})
@@ -139,20 +112,7 @@ func TestNewESDTNFTCreateFunc_NilArgumentsShouldErr(t *testing.T) {
 func TestNewESDTNFTCreateFunc(t *testing.T) {
 	t.Parallel()
 
-	nftCreate, err := NewESDTNFTCreateFunc(
-		0,
-		vmcommon.BaseOperationCost{},
-		&mock.MarshalizerMock{},
-		&mock.GlobalSettingsHandlerStub{},
-		&mock.ESDTRoleHandlerStub{},
-		createNewESDTDataStorageHandler(),
-		&mock.AccountsStub{},
-		&mock.EnableEpochsHandlerStub{
-			IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
-				return flag == ValueLengthCheckFlag
-			},
-		},
-	)
+	nftCreate, err := NewESDTNFTCreateFunc(createESDTNFTCreateArgs())
 	assert.False(t, check.IfNil(nftCreate))
 	assert.Nil(t, err)
 }
@@ -234,25 +194,17 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionNotAllowedToExecute(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	esdtDataStorage := createNewESDTDataStorageHandler()
-	nftCreate, _ := NewESDTNFTCreateFunc(
-		0,
-		vmcommon.BaseOperationCost{},
-		&mock.MarshalizerMock{},
-		&mock.GlobalSettingsHandlerStub{},
-		&mock.ESDTRoleHandlerStub{
-			CheckAllowedToExecuteCalled: func(account vmcommon.UserAccountHandler, tokenID []byte, action []byte) error {
-				return expectedErr
-			},
+	esdtDtaStorage := createNewESDTDataStorageHandler()
+
+	args := createESDTNFTCreateArgs()
+	args.EsdtStorageHandler = esdtDtaStorage
+	args.Accounts = esdtDtaStorage.accounts
+	args.RolesHandler = &mock.ESDTRoleHandlerStub{
+		CheckAllowedToExecuteCalled: func(account vmcommon.UserAccountHandler, tokenID []byte, action []byte) error {
+			return expectedErr
 		},
-		esdtDataStorage,
-		esdtDataStorage.accounts,
-		&mock.EnableEpochsHandlerStub{
-			IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
-				return flag == ValueLengthCheckFlag
-			},
-		},
-	)
+	}
+	nftCreate, _ := NewESDTNFTCreateFunc(args)
 	sender := mock.NewAccountWrapMock([]byte("address"))
 	vmInput := &vmcommon.ContractCallInput{
 		VMInput: vmcommon.VMInput{
@@ -270,7 +222,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionNotAllowedToExecute(t *testing.T) {
 func TestEsdtNFTCreate_ProcessBuiltinFunctionShouldWork(t *testing.T) {
 	t.Parallel()
 
-	esdtDataStorage := createNewESDTDataStorageHandler()
+	esdtDtaStorage := createNewESDTDataStorageHandler()
 	firstCheck := true
 	esdtRoleHandler := &mock.ESDTRoleHandlerStub{
 		CheckAllowedToExecuteCalled: func(account vmcommon.UserAccountHandler, tokenID []byte, action []byte) error {
@@ -283,20 +235,12 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionShouldWork(t *testing.T) {
 			return nil
 		},
 	}
-	nftCreate, _ := NewESDTNFTCreateFunc(
-		0,
-		vmcommon.BaseOperationCost{},
-		&mock.MarshalizerMock{},
-		&mock.GlobalSettingsHandlerStub{},
-		esdtRoleHandler,
-		esdtDataStorage,
-		esdtDataStorage.accounts,
-		&mock.EnableEpochsHandlerStub{
-			IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
-				return flag == ValueLengthCheckFlag
-			},
-		},
-	)
+	args := createESDTNFTCreateArgs()
+	args.RolesHandler = esdtRoleHandler
+	args.Accounts = esdtDtaStorage.accounts
+	args.EsdtStorageHandler = esdtDtaStorage
+
+	nftCreate, _ := NewESDTNFTCreateFunc(args)
 	address := bytes.Repeat([]byte{1}, 32)
 	sender := mock.NewUserAccount(address)
 	//add some data in the trie, otherwise the creation will fail (it won't happen in real case usage as the create NFT
@@ -352,7 +296,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionShouldWork(t *testing.T) {
 	tokenKey := []byte(baseESDTKeyPrefix + token)
 	tokenKey = append(tokenKey, big.NewInt(1).Bytes()...)
 
-	esdtData, _, _ := esdtDataStorage.getESDTDigitalTokenDataFromSystemAccount(tokenKey, defaultQueryOptions())
+	esdtData, _, _ := esdtDtaStorage.getESDTDigitalTokenDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	assert.Equal(t, tokenMetaData, esdtData.TokenMetaData)
 	assert.Equal(t, esdtData.Value, quantity)
 
@@ -371,17 +315,14 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionWithExecByCaller(t *testing.T) {
 			return flag == ValueLengthCheckFlag || flag == SaveToSystemAccountFlag || flag == CheckFrozenCollectionFlag
 		},
 	}
-	esdtDataStorage := createNewESDTDataStorageHandlerWithArgs(&mock.GlobalSettingsHandlerStub{}, accounts, enableEpochsHandler)
-	nftCreate, _ := NewESDTNFTCreateFunc(
-		0,
-		vmcommon.BaseOperationCost{},
-		&mock.MarshalizerMock{},
-		&mock.GlobalSettingsHandlerStub{},
-		&mock.ESDTRoleHandlerStub{},
-		esdtDataStorage,
-		esdtDataStorage.accounts,
-		enableEpochsHandler,
-	)
+	esdtDtaStorage := createNewESDTDataStorageHandlerWithArgs(&mock.GlobalSettingsHandlerStub{}, accounts, enableEpochsHandler)
+
+	args := createESDTNFTCreateArgs()
+	args.EnableEpochsHandler = enableEpochsHandler
+	args.Accounts = esdtDtaStorage.accounts
+	args.EsdtStorageHandler = esdtDtaStorage
+
+	nftCreate, _ := NewESDTNFTCreateFunc(args)
 	address := bytes.Repeat([]byte{1}, 32)
 	userAddress := bytes.Repeat([]byte{2}, 32)
 	token := "token"
@@ -437,7 +378,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionWithExecByCaller(t *testing.T) {
 	tokenKey := []byte(baseESDTKeyPrefix + token)
 	tokenKey = append(tokenKey, big.NewInt(1).Bytes()...)
 
-	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey, defaultQueryOptions())
+	metaData, _ := esdtDtaStorage.getESDTMetaDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	assert.Equal(t, tokenMetaData, metaData)
 }
 

--- a/builtInFunctions/esdtNFTCreate_test.go
+++ b/builtInFunctions/esdtNFTCreate_test.go
@@ -391,7 +391,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainToken(t *testing.T) {
 	esdtRoleHandler, _ := NewESDTRolesFunc(marshallerMock, ctc, false)
 
 	args := createESDTNFTCreateArgs()
-	args.CrossChainTokenCheckerHandler, _ = NewCrossChainTokenChecker(nil, getWhiteListedAddress())
+	args.CrossChainTokenCheckerHandler = ctc
 	args.RolesHandler = esdtRoleHandler
 	args.Accounts = esdtDtaStorage.accounts
 	args.EsdtStorageHandler = esdtDtaStorage
@@ -470,7 +470,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainTokenErrorCases(t *testin
 	esdtRoleHandler, _ := NewESDTRolesFunc(marshallerMock, ctc, false)
 
 	args := createESDTNFTCreateArgs()
-	args.CrossChainTokenCheckerHandler, _ = NewCrossChainTokenChecker(nil, getWhiteListedAddress())
+	args.CrossChainTokenCheckerHandler = ctc
 	args.RolesHandler = esdtRoleHandler
 	args.Accounts = esdtDtaStorage.accounts
 	args.EsdtStorageHandler = esdtDtaStorage
@@ -480,28 +480,23 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainTokenErrorCases(t *testin
 	sender := mock.NewUserAccount(address)
 
 	t.Run("invalid num of args, last arg is not nonce", func(t *testing.T) {
-		token := "sov1-TOKEN-abcdef"
-		quantity := big.NewInt(2)
-		name := "name"
-		royalties := 100 //1%
-		hash := []byte("12345678901234567890123456789012")
-		attributes := []byte("attributes")
 		vmInput := &vmcommon.ContractCallInput{
 			VMInput: vmcommon.VMInput{
 				CallerAddr: sender.AddressBytes(),
 				CallValue:  big.NewInt(0),
 				Arguments: [][]byte{
-					[]byte(token),
-					quantity.Bytes(),
-					[]byte(name),
-					big.NewInt(int64(royalties)).Bytes(),
-					hash,
-					attributes,
+					[]byte("sov1-TOKEN-abcdef"),
+					big.NewInt(2).Bytes(),
+					[]byte("name"),
+					big.NewInt(int64(100)).Bytes(),
+					[]byte("12345678901234567890123456789012"),
+					[]byte("attributes"),
 					[]byte("uri1"),
 				},
 			},
 			RecipientAddr: sender.AddressBytes(),
 		}
+
 		vmOutput, err := nftCreate.ProcessBuiltinFunction(sender, nil, vmInput)
 		require.ErrorIs(t, err, ErrInvalidNumberOfArguments)
 		require.True(t, strings.Contains(err.Error(), "for cross chain"))
@@ -510,30 +505,24 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainTokenErrorCases(t *testin
 
 	t.Run("address is not whitelisted", func(t *testing.T) {
 		senderInvalid := mock.NewUserAccount([]byte("notWhiteListed"))
-
-		token := "sov1-TOKEN-abcdef"
-		quantity := big.NewInt(2)
-		name := "name"
-		royalties := 100 //1%
-		hash := []byte("12345678901234567890123456789012")
-		attributes := []byte("attributes")
 		vmInput := &vmcommon.ContractCallInput{
 			VMInput: vmcommon.VMInput{
 				CallerAddr: senderInvalid.AddressBytes(),
 				CallValue:  big.NewInt(0),
 				Arguments: [][]byte{
-					[]byte(token),
-					quantity.Bytes(),
-					[]byte(name),
-					big.NewInt(int64(royalties)).Bytes(),
-					hash,
-					attributes,
+					[]byte("sov1-TOKEN-abcdef"),
+					big.NewInt(2).Bytes(),
+					[]byte("name"),
+					big.NewInt(int64(100)).Bytes(),
+					[]byte("12345678901234567890123456789012"),
+					[]byte("attributes"),
 					[]byte("uri1"),
 					big.NewInt(123).Bytes(),
 				},
 			},
 			RecipientAddr: senderInvalid.AddressBytes(),
 		}
+
 		vmOutput, err := nftCreate.ProcessBuiltinFunction(senderInvalid, nil, vmInput)
 		require.Equal(t, err, ErrActionNotAllowed)
 		require.Nil(t, vmOutput)


### PR DESCRIPTION
- Allow nft esdt cross chain token mint with the same nonce(that it came from another sovereign chain)
- Nonce should be the last args in vm input and the address should be whitelisted
- Nonce will not be incremented and saved in account's storage