### PR TITLE
esdt improvements refactor

### DIFF
--- a/builtInFunctions/errors.go
+++ b/builtInFunctions/errors.go
@@ -220,3 +220,6 @@ var ErrInvalidVersion = errors.New("invalid version")
 
 // ErrNilBlockchainHook signals that a nil blockchain hook has been provided
 var ErrNilBlockchainHook = errors.New("nil blockchain hook")
+
+// ErrTypeNotSetInsideGlobalSettingsHandler signals that type is not set inside global settings handler
+var ErrTypeNotSetInsideGlobalSettingsHandler = errors.New("type not set inside global settings handler")

--- a/builtInFunctions/esdtDataStorage.go
+++ b/builtInFunctions/esdtDataStorage.go
@@ -427,7 +427,7 @@ func (e *esdtDataStorage) checkTheCorrectTokenTypeIsSet(esdtData *esdt.ESDigital
 	return false
 }
 
-// removeNFTMetadataFromSystemAccountIfNeeded removes the NFT metadata from the system account if needed
+// there should be a match between the token type on the system account (from globalSettingsHandler) and the token type on the user account.
 func (e *esdtDataStorage) migrateTokenTypeAndMetadataIfNeeded(esdtTokenKey []byte, nonce uint64, esdtData *esdt.ESDigitalToken) error {
 	if !e.enableEpochsHandler.IsFlagEnabled(DynamicEsdtFlag) {
 		return nil

--- a/builtInFunctions/esdtDataStorage_test.go
+++ b/builtInFunctions/esdtDataStorage_test.go
@@ -615,18 +615,11 @@ func TestEsdtDataStorage_SaveESDTNFTToken(t *testing.T) {
 		nonce := uint64(10)
 		key := baseESDTKeyPrefix + tokenIdentifier
 		tokenKey := append([]byte(key), big.NewInt(int64(nonce)).Bytes()...)
-		setTokenTypeCalled := false
 
 		args := createMockArgsForNewESDTDataStorage()
 		args.GlobalSettingsHandler = &mock.GlobalSettingsHandlerStub{
 			GetTokenTypeCalled: func(esdtTokenKey []byte) (uint32, error) {
 				return uint32(core.NonFungibleV2), nil
-			},
-			SetTokenTypeCalled: func(esdtTokenKey []byte, tokenType uint32) error {
-				assert.Equal(t, []byte(key), esdtTokenKey)
-				assert.Equal(t, uint32(core.NonFungibleV2), tokenType)
-				setTokenTypeCalled = true
-				return nil
 			},
 		}
 		args.EnableEpochsHandler = &mock.EnableEpochsHandlerStub{
@@ -657,7 +650,6 @@ func TestEsdtDataStorage_SaveESDTNFTToken(t *testing.T) {
 
 		_, err := dataStorage.SaveESDTNFTToken([]byte("address"), userAcc, []byte(key), nonce, nftToken, false, false)
 		assert.Nil(t, err)
-		assert.True(t, setTokenTypeCalled)
 
 		// metadata has been removed from the system account
 		val, _, _ := systemAcc.AccountDataHandler().RetrieveValue(tokenKey)

--- a/builtInFunctions/esdtGlobalSettings.go
+++ b/builtInFunctions/esdtGlobalSettings.go
@@ -2,11 +2,30 @@ package builtInFunctions
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"math"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-vm-common-go"
+)
+
+// ESDTTypeForGlobalSettingsHandler is needed because if 0 is retrieved from the global settings handler,
+// it means either that the type is not set or that the type is fungible. This will solve the ambiguity.
+type ESDTTypeForGlobalSettingsHandler uint32
+
+const (
+	notSet ESDTTypeForGlobalSettingsHandler = iota
+	fungible
+	nonFungible
+	nonFungibleV2
+	metaFungible
+	semiFungible
+	dynamicNFT
+	dynamicSFT
+	dynamicMeta
 )
 
 type esdtGlobalSettings struct {
@@ -219,11 +238,24 @@ func (e *esdtGlobalSettings) GetTokenType(esdtTokenKey []byte) (uint32, error) {
 		return 0, err
 	}
 
-	return uint32(esdtMetaData.TokenType), nil
+	tokenType, err := convertToESDTTokenType(uint32(esdtMetaData.TokenType))
+	if errors.Is(err, ErrTypeNotSetInsideGlobalSettingsHandler) {
+		return uint32(core.NonFungible), nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	return tokenType, nil
 }
 
 // SetTokenType sets the token type for the esdtTokenKey
 func (e *esdtGlobalSettings) SetTokenType(esdtTokenKey []byte, tokenType uint32) error {
+	globalSettingsTokenType, err := convertToGlobalSettingsHandlerTokenType(tokenType)
+	if err != nil {
+		return err
+	}
+
 	systemAccount, err := getSystemAccount(e.accounts)
 	if err != nil {
 		return err
@@ -234,7 +266,7 @@ func (e *esdtGlobalSettings) SetTokenType(esdtTokenKey []byte, tokenType uint32)
 		return err
 	}
 	esdtMetaData := ESDTGlobalMetadataFromBytes(val)
-	esdtMetaData.TokenType = byte(tokenType)
+	esdtMetaData.TokenType = byte(globalSettingsTokenType)
 
 	err = systemAccount.AccountDataHandler().SaveKeyValue(esdtTokenKey, esdtMetaData.ToBytes())
 	if err != nil {
@@ -242,6 +274,54 @@ func (e *esdtGlobalSettings) SetTokenType(esdtTokenKey []byte, tokenType uint32)
 	}
 
 	return e.accounts.SaveAccount(systemAccount)
+}
+
+func convertToGlobalSettingsHandlerTokenType(esdtType uint32) (uint32, error) {
+	switch esdtType {
+	case uint32(core.Fungible):
+		return uint32(fungible), nil
+	case uint32(core.NonFungible):
+		return uint32(nonFungible), nil
+	case uint32(core.NonFungibleV2):
+		return uint32(nonFungibleV2), nil
+	case uint32(core.MetaFungible):
+		return uint32(metaFungible), nil
+	case uint32(core.SemiFungible):
+		return uint32(semiFungible), nil
+	case uint32(core.DynamicNFT):
+		return uint32(dynamicNFT), nil
+	case uint32(core.DynamicSFT):
+		return uint32(dynamicSFT), nil
+	case uint32(core.DynamicMeta):
+		return uint32(dynamicMeta), nil
+	default:
+		return math.MaxUint32, fmt.Errorf("invalid esdt type: %d", esdtType)
+	}
+}
+
+func convertToESDTTokenType(esdtType uint32) (uint32, error) {
+	switch ESDTTypeForGlobalSettingsHandler(esdtType) {
+	case notSet:
+		return 0, ErrTypeNotSetInsideGlobalSettingsHandler
+	case fungible:
+		return uint32(core.Fungible), nil
+	case nonFungible:
+		return uint32(core.NonFungible), nil
+	case nonFungibleV2:
+		return uint32(core.NonFungibleV2), nil
+	case metaFungible:
+		return uint32(core.MetaFungible), nil
+	case semiFungible:
+		return uint32(core.SemiFungible), nil
+	case dynamicNFT:
+		return uint32(core.DynamicNFT), nil
+	case dynamicSFT:
+		return uint32(core.DynamicSFT), nil
+	case dynamicMeta:
+		return uint32(core.DynamicMeta), nil
+	default:
+		return math.MaxUint32, fmt.Errorf("invalid esdt type: %d", esdtType)
+	}
 }
 
 // IsInterfaceNil returns true if underlying object in nil

--- a/builtInFunctions/esdtGlobalSettings_test.go
+++ b/builtInFunctions/esdtGlobalSettings_test.go
@@ -2,7 +2,9 @@ package builtInFunctions
 
 import (
 	"errors"
+	"github.com/stretchr/testify/require"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -295,4 +297,117 @@ func TestESDTGlobalSettingsBurnForAll_ProcessBuiltInFunction(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.False(t, globalSettingsFunc.IsLimitedTransfer(tokenID))
+}
+
+func TestEsdtGlobalSettings_SetTokenType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid token type", func(t *testing.T) {
+		t.Parallel()
+
+		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)
+		globalSettingsFunc, _ := NewESDTGlobalSettingsFunc(
+			&mock.AccountsStub{
+				LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+					return acnt, nil
+				},
+			},
+			&mock.MarshalizerMock{},
+			true,
+			core.BuiltInFunctionESDTPause,
+			falseHandler,
+		)
+
+		err := globalSettingsFunc.SetTokenType([]byte("key"), 100)
+		require.True(t, strings.Contains(err.Error(), "invalid esdt type"))
+	})
+	t.Run("fungible token type", func(t *testing.T) {
+		t.Parallel()
+
+		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)
+		globalSettingsFunc, _ := NewESDTGlobalSettingsFunc(
+			&mock.AccountsStub{
+				LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+					return acnt, nil
+				},
+			},
+			&mock.MarshalizerMock{},
+			true,
+			core.BuiltInFunctionESDTPause,
+			falseHandler,
+		)
+
+		err := globalSettingsFunc.SetTokenType([]byte("key"), uint32(core.Fungible))
+		require.Nil(t, err)
+		retrievedVal := acnt.Storage["key"]
+		require.Equal(t, []byte{0, 1}, retrievedVal)
+	})
+}
+
+func TestEsdtGlobalSettings_GetTokenType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("token type not set", func(t *testing.T) {
+		t.Parallel()
+
+		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)
+		globalSettingsFunc, _ := NewESDTGlobalSettingsFunc(
+			&mock.AccountsStub{
+				LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+					return acnt, nil
+				},
+			},
+			&mock.MarshalizerMock{},
+			true,
+			core.BuiltInFunctionESDTPause,
+			falseHandler,
+		)
+
+		acnt.Storage["key"] = []byte{byte(notSet)}
+		val, err := globalSettingsFunc.GetTokenType([]byte("key"))
+		require.Nil(t, err)
+		require.Equal(t, uint32(core.NonFungible), val)
+	})
+	t.Run("retrieve token type error ", func(t *testing.T) {
+		t.Parallel()
+
+		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)
+		globalSettingsFunc, _ := NewESDTGlobalSettingsFunc(
+			&mock.AccountsStub{
+				LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+					return acnt, nil
+				},
+			},
+			&mock.MarshalizerMock{},
+			true,
+			core.BuiltInFunctionESDTPause,
+			falseHandler,
+		)
+
+		acnt.Storage["key"] = []byte{0, 100}
+		val, err := globalSettingsFunc.GetTokenType([]byte("key"))
+		require.True(t, strings.Contains(err.Error(), "invalid esdt type"))
+		require.Equal(t, uint32(0), val)
+	})
+	t.Run("convert to esdt token type error", func(t *testing.T) {
+		t.Parallel()
+
+		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)
+		globalSettingsFunc, _ := NewESDTGlobalSettingsFunc(
+			&mock.AccountsStub{
+				LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+					return acnt, nil
+				},
+			},
+			&mock.MarshalizerMock{},
+			true,
+			core.BuiltInFunctionESDTPause,
+			falseHandler,
+		)
+
+		acnt.Storage["key"] = []byte{0, byte(fungible)}
+		val, err := globalSettingsFunc.GetTokenType([]byte("key"))
+		require.Nil(t, err)
+		require.Equal(t, uint32(core.Fungible), val)
+	})
 }

--- a/builtInFunctions/esdtGlobalSettings_test.go
+++ b/builtInFunctions/esdtGlobalSettings_test.go
@@ -368,7 +368,7 @@ func TestEsdtGlobalSettings_GetTokenType(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, uint32(core.NonFungible), val)
 	})
-	t.Run("retrieve token type error ", func(t *testing.T) {
+	t.Run("retrieve token type error", func(t *testing.T) {
 		t.Parallel()
 
 		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)
@@ -389,7 +389,7 @@ func TestEsdtGlobalSettings_GetTokenType(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), "invalid esdt type"))
 		require.Equal(t, uint32(0), val)
 	})
-	t.Run("convert to esdt token type error", func(t *testing.T) {
+	t.Run("convert to esdt token type", func(t *testing.T) {
 		t.Parallel()
 
 		acnt := mock.NewUserAccount(vmcommon.SystemAccountAddress)


### PR DESCRIPTION
This refactor has two pourposes:

1. If a token type is migrated (the token type is correctly set inside the esdtData), do not access the `globalSettingsHandler`, which saves it's data inside the system account
2. Also save the token type in the esdtData for SFTs & metaESDTs