### PR TITLE
integrate token type from vmInput

### DIFF
--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -20,9 +20,10 @@ var (
 	noncePrefix = []byte(core.ProtectedKeyPrefix + core.ESDTNFTLatestNonceIdentifier)
 )
 
-const minNumOfArgsForCrossChainMint = 9
+const minNumOfArgsForCrossChainMint = 10
 
 type esdtNFTCreateInput struct {
+	esdtType              uint32
 	nonce                 uint64
 	originalCreator       []byte
 	uris                  [][]byte
@@ -174,7 +175,8 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 		return nil, err
 	}
 
-	nonce, originalCreator, uris, isCrossChainToken :=
+	esdtType, nonce, originalCreator, uris, isCrossChainToken :=
+		createInput.esdtType,
 		createInput.nonce,
 		createInput.originalCreator,
 		createInput.uris,
@@ -208,11 +210,6 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 	isValueLengthCheckFlagEnabled := e.enableEpochsHandler.IsFlagEnabled(ValueLengthCheckFlag)
 	if isValueLengthCheckFlagEnabled && len(vmInput.Arguments[1]) > maxLenForAddNFTQuantity {
 		return nil, fmt.Errorf("%w max length for quantity in nft create is %d", ErrInvalidArguments, maxLenForAddNFTQuantity)
-	}
-
-	esdtType, err := e.getTokenType(tokenID)
-	if err != nil {
-		return nil, err
 	}
 
 	nextNonce := nonce
@@ -319,12 +316,18 @@ func (e *esdtNFTCreate) getESDTNFTCreateInput(
 	args := vmInput.Arguments
 
 	var uris = originalURIs
+	var esdtType uint32
 	var nonce uint64
 	var originalCreator []byte
 	var err error
 
 	isCrossChainToken := e.crossChainTokenCheckerHandler.IsCrossChainOperation(tokenID)
 	if !isCrossChainToken {
+		esdtType, err = e.getTokenType(tokenID)
+		if err != nil {
+			return nil, err
+		}
+
 		nonce, err = getLatestNonce(accountWithRoles, tokenID)
 		if err != nil {
 			return nil, err
@@ -332,15 +335,16 @@ func (e *esdtNFTCreate) getESDTNFTCreateInput(
 
 		originalCreator = vmInput.CallerAddr
 	} else {
-		nonce, originalCreator, err = getCrossChainTokenNonceAndCreator(args, vmInput.CallType)
+		esdtType, nonce, originalCreator, err = getCrossChainTokenNonceAndCreator(args, vmInput.CallType)
 		if err != nil {
 			return nil, err
 		}
 
-		uris = uris[:len(uris)-2]
+		uris = uris[:len(uris)-3]
 	}
 
 	return &esdtNFTCreateInput{
+		esdtType:              esdtType,
 		nonce:                 nonce,
 		originalCreator:       originalCreator,
 		uris:                  uris,
@@ -348,7 +352,7 @@ func (e *esdtNFTCreate) getESDTNFTCreateInput(
 	}, nil
 }
 
-func getCrossChainTokenNonceAndCreator(args [][]byte, callType vm.CallType) (uint64, []byte, error) {
+func getCrossChainTokenNonceAndCreator(args [][]byte, callType vm.CallType) (uint32, uint64, []byte, error) {
 	minRequiredArgs := minNumOfArgsForCrossChainMint
 	if callType == vm.ExecOnDestByCaller {
 		minRequiredArgs++
@@ -356,17 +360,19 @@ func getCrossChainTokenNonceAndCreator(args [][]byte, callType vm.CallType) (uin
 
 	argsLen := len(args)
 	if argsLen < minRequiredArgs {
-		return 0, nil, fmt.Errorf("%w for cross chain token mint, received: %d, expected: %d, 2 extra arguments should be the nonce and original creator",
+		return 0, 0, nil, fmt.Errorf("%w for cross chain token mint, received: %d, expected: %d, 2 extra arguments should be the nonce and original creator",
 			ErrInvalidNumberOfArguments, argsLen, minRequiredArgs)
 	}
 
 	if !(callType == vm.ExecOnDestByCaller) {
+		esdtTypeBytes := args[argsLen-3]
 		nonceBytes := args[argsLen-2]
-		return big.NewInt(0).SetBytes(nonceBytes).Uint64(), args[argsLen-1], nil
+		return uint32(big.NewInt(0).SetBytes(esdtTypeBytes).Uint64()), big.NewInt(0).SetBytes(nonceBytes).Uint64(), args[argsLen-1], nil
 	}
 
+	esdtTypeBytes := args[argsLen-4]
 	nonceBytes := args[len(args)-3]
-	return big.NewInt(0).SetBytes(nonceBytes).Uint64(), args[argsLen-2], nil
+	return uint32(big.NewInt(0).SetBytes(esdtTypeBytes).Uint64()), big.NewInt(0).SetBytes(nonceBytes).Uint64(), args[argsLen-2], nil
 }
 
 func saveLatestNonce(acnt vmcommon.UserAccountHandler, tokenID []byte, nonce uint64) error {

--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -341,7 +341,7 @@ func (e *esdtNFTCreate) getESDTNFTCreateInput(
 
 		originalCreator = vmInput.CallerAddr
 	} else {
-		esdtData, err := getCrossChainEsdtData(args, vmInput.CallType)
+		esdtData, err := getCrossChainESDTData(args, vmInput.CallType)
 		if err != nil {
 			return nil, err
 		}
@@ -362,7 +362,7 @@ func (e *esdtNFTCreate) getESDTNFTCreateInput(
 	}, nil
 }
 
-func getCrossChainEsdtData(args [][]byte, callType vm.CallType) (*esdtNFTCrossChainData, error) {
+func getCrossChainESDTData(args [][]byte, callType vm.CallType) (*esdtNFTCrossChainData, error) {
 	minRequiredArgs := minNumOfArgsForCrossChainMint
 	if callType == vm.ExecOnDestByCaller {
 		minRequiredArgs++

--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -376,20 +376,20 @@ func getCrossChainESDTData(args [][]byte, callType vm.CallType) (*esdtNFTCrossCh
 
 	if !(callType == vm.ExecOnDestByCaller) {
 		return &esdtNFTCrossChainData{
-			esdtType:        uint32(getUin46FromBytes(args[argsLen-3])),
-			nonce:           getUin46FromBytes(args[argsLen-2]),
+			esdtType:        uint32(getUIn46FromBytes(args[argsLen-3])),
+			nonce:           getUIn46FromBytes(args[argsLen-2]),
 			originalCreator: args[argsLen-1],
 		}, nil
 	}
 
 	return &esdtNFTCrossChainData{
-		esdtType:        uint32(getUin46FromBytes(args[argsLen-4])),
-		nonce:           getUin46FromBytes(args[argsLen-3]),
+		esdtType:        uint32(getUIn46FromBytes(args[argsLen-4])),
+		nonce:           getUIn46FromBytes(args[argsLen-3]),
 		originalCreator: args[argsLen-2],
 	}, nil
 }
 
-func getUin46FromBytes(value []byte) uint64 {
+func getUIn46FromBytes(value []byte) uint64 {
 	return big.NewInt(0).SetBytes(value).Uint64()
 }
 

--- a/builtInFunctions/esdtNFTCreate_test.go
+++ b/builtInFunctions/esdtNFTCreate_test.go
@@ -407,8 +407,9 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionWithExecByCallerCrossChainToken(t *
 	whiteListedAddr := []byte("whiteListedAddress")
 	userAddr := []byte("userAccountAddress")
 	token := "sov1-TOKEN-abcdef"
+	tokenType := core.NonFungible
 	nonce := big.NewInt(1234)
-	quantity := big.NewInt(2)
+	quantity := big.NewInt(1)
 	name := "name"
 	royalties := 100 //1%
 	hash := []byte("12345678901234567890123456789012")
@@ -428,6 +429,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionWithExecByCallerCrossChainToken(t *
 				attributes,
 				uris[0],
 				uris[1],
+				big.NewInt(int64(tokenType)).Bytes(),
 				nonce.Bytes(),
 				originalCreator,
 				whiteListedAddr,
@@ -482,6 +484,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainToken(t *testing.T) {
 	sender := mock.NewUserAccount(address)
 
 	token := "sov1-TOKEN-abcdef"
+	tokenType := core.SemiFungible
 	quantity := big.NewInt(2)
 	name := "name"
 	royalties := 100 //1%
@@ -503,6 +506,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainToken(t *testing.T) {
 				attributes,
 				uris[0],
 				uris[1],
+				big.NewInt(int64(tokenType)).Bytes(),
 				nonce.Bytes(),
 				originalCreator,
 			},
@@ -537,6 +541,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainToken(t *testing.T) {
 	esdtData, _, _ := esdtDtaStorage.getESDTDigitalTokenDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	require.Equal(t, tokenMetaData, esdtData.TokenMetaData)
 	require.Equal(t, esdtData.Value, quantity)
+	require.Equal(t, esdtData.Type, uint32(tokenType))
 
 	esdtDataBytes := vmOutput.Logs[0].Topics[3]
 	var esdtDataFromLog esdt.ESDigitalToken
@@ -557,6 +562,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionCrossChainToken(t *testing.T) {
 				hash,
 				attributes,
 				uris[0],
+				big.NewInt(int64(tokenType)).Bytes(),
 				nonce.Bytes(),
 				originalCreator,
 			},


### PR DESCRIPTION
For normal NFT create, the TokenType is taken from system account. For cross-chain NFTCreate we need to send TokenType in vmInput (same as nonce and creator) because we don't have information in system account.